### PR TITLE
PBI-006: SQL Repository Pattern and Unit of Work

### DIFF
--- a/FF.API/Program.cs
+++ b/FF.API/Program.cs
@@ -1,10 +1,12 @@
 using FF.API.Middleware;
+using FF.Application.Interfaces.Persistence;
+using FF.Infrastructure.Persistence.Mongo;
 using FF.Infrastructure.Persistence.SQL;
+using FF.Infrastructure.Persistence.SQL.Repositories;
 using FF.Infrastructure.Persistence.SQL.Seed;
 using Microsoft.EntityFrameworkCore;
 using Serilog;
 using Serilog.Events;
-using FF.Infrastructure.Persistence.Mongo;
 
 Serilog.Debugging.SelfLog.Enable(msg => Console.WriteLine($"SERILOG: {msg}"));
 
@@ -47,6 +49,11 @@ try
                     errorNumbersToAdd: null);
             }));
 
+    // Repository Pattern
+    builder.Services.AddScoped<IUnitOfWork, UnitOfWork>();
+    builder.Services.AddScoped<IPlayerRepository, PlayerRepository>();
+    builder.Services.AddScoped<ILeagueRepository, LeagueRepository>();
+    builder.Services.AddScoped<IRosterRepository, RosterRepository>();
 
     // ── MONGODB ───────────────────────────────────────────────
     builder.Services.AddSingleton<MongoDbContext>();

--- a/FF.Infrastructure/Persistence/ILeagueRepository.cs
+++ b/FF.Infrastructure/Persistence/ILeagueRepository.cs
@@ -1,0 +1,9 @@
+﻿using FF.Domain.Entities;
+
+namespace FF.Application.Interfaces.Persistence;
+
+public interface ILeagueRepository : IRepository<League>
+{
+    Task<League?> GetBySleeperIdAsync(string sleeperLeagueId, int season, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<League>> GetActiveLeaguesAsync(CancellationToken cancellationToken = default);
+}

--- a/FF.Infrastructure/Persistence/IPlayerRepository.cs
+++ b/FF.Infrastructure/Persistence/IPlayerRepository.cs
@@ -1,0 +1,11 @@
+﻿using FF.Domain.Entities;
+using FF.Domain.Enums;
+
+namespace FF.Application.Interfaces.Persistence;
+
+public interface IPlayerRepository : IRepository<Player>
+{
+    Task<Player?> GetBySleeperIdAsync(string sleeperPlayerId, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<Player>> GetByPositionAsync(Position position, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<Player>> GetByNflTeamAsync(string nflTeam, CancellationToken cancellationToken = default);
+}

--- a/FF.Infrastructure/Persistence/IRepository.cs
+++ b/FF.Infrastructure/Persistence/IRepository.cs
@@ -1,0 +1,12 @@
+﻿using FF.SharedKernel;
+
+namespace FF.Application.Interfaces.Persistence;
+
+public interface IRepository<T> where T : Entity
+{
+    Task<T?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<T>> GetAllAsync(CancellationToken cancellationToken = default);
+    Task AddAsync(T entity, CancellationToken cancellationToken = default);
+    void Update(T entity);
+    void Remove(T entity);
+}

--- a/FF.Infrastructure/Persistence/IRosterRepository.cs
+++ b/FF.Infrastructure/Persistence/IRosterRepository.cs
@@ -1,0 +1,9 @@
+﻿using FF.Domain.Entities;
+
+namespace FF.Application.Interfaces.Persistence;
+
+public interface IRosterRepository : IRepository<Roster>
+{
+    Task<IReadOnlyList<Roster>> GetByLeagueIdAsync(Guid leagueId, CancellationToken cancellationToken = default);
+    Task<Roster?> GetBySleeperRosterIdAsync(string sleeperRosterId, CancellationToken cancellationToken = default);
+}

--- a/FF.Infrastructure/Persistence/IUnitOfWork.cs
+++ b/FF.Infrastructure/Persistence/IUnitOfWork.cs
@@ -1,0 +1,9 @@
+﻿namespace FF.Application.Interfaces.Persistence;
+
+public interface IUnitOfWork : IDisposable
+{
+    IPlayerRepository Players { get; }
+    ILeagueRepository Leagues { get; }
+    IRosterRepository Rosters { get; }
+    Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
+}

--- a/FF.Infrastructure/Persistence/SQL/Repositories/BaseRepository.cs
+++ b/FF.Infrastructure/Persistence/SQL/Repositories/BaseRepository.cs
@@ -1,0 +1,32 @@
+﻿using FF.Application.Interfaces.Persistence;
+using FF.SharedKernel;
+using Microsoft.EntityFrameworkCore;
+
+namespace FF.Infrastructure.Persistence.SQL.Repositories;
+
+public abstract class BaseRepository<T> : IRepository<T> where T : Entity
+{
+    protected readonly FFDbContext Context;
+    protected readonly DbSet<T> DbSet;
+
+    protected BaseRepository(FFDbContext context)
+    {
+        Context = context;
+        DbSet = context.Set<T>();
+    }
+
+    public async Task<T?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+        => await DbSet.FindAsync([id], cancellationToken);
+
+    public async Task<IReadOnlyList<T>> GetAllAsync(CancellationToken cancellationToken = default)
+        => await DbSet.AsNoTracking().ToListAsync(cancellationToken);
+
+    public async Task AddAsync(T entity, CancellationToken cancellationToken = default)
+        => await DbSet.AddAsync(entity, cancellationToken);
+
+    public void Update(T entity)
+        => DbSet.Update(entity);
+
+    public void Remove(T entity)
+        => DbSet.Remove(entity);
+}

--- a/FF.Infrastructure/Persistence/SQL/Repositories/LeagueRepository.cs
+++ b/FF.Infrastructure/Persistence/SQL/Repositories/LeagueRepository.cs
@@ -1,0 +1,20 @@
+﻿using FF.Application.Interfaces.Persistence;
+using FF.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace FF.Infrastructure.Persistence.SQL.Repositories;
+
+public class LeagueRepository : BaseRepository<League>, ILeagueRepository
+{
+    public LeagueRepository(FFDbContext context) : base(context) { }
+
+    public async Task<League?> GetBySleeperIdAsync(string sleeperLeagueId, int season, CancellationToken cancellationToken = default)
+        => await DbSet.AsNoTracking()
+            .FirstOrDefaultAsync(l => l.SleeperLeagueId == sleeperLeagueId && l.Season == season, cancellationToken);
+
+    public async Task<IReadOnlyList<League>> GetActiveLeaguesAsync(CancellationToken cancellationToken = default)
+        => await DbSet.AsNoTracking()
+            .Where(l => l.IsActive)
+            .OrderBy(l => l.Name)
+            .ToListAsync(cancellationToken);
+}

--- a/FF.Infrastructure/Persistence/SQL/Repositories/PlayerRepository.cs
+++ b/FF.Infrastructure/Persistence/SQL/Repositories/PlayerRepository.cs
@@ -1,0 +1,28 @@
+﻿using FF.Application.Interfaces.Persistence;
+using FF.Domain.Entities;
+using FF.Domain.Enums;
+using Microsoft.EntityFrameworkCore;
+
+namespace FF.Infrastructure.Persistence.SQL.Repositories;
+
+public class PlayerRepository : BaseRepository<Player>, IPlayerRepository
+{
+    public PlayerRepository(FFDbContext context) : base(context) { }
+
+    public async Task<Player?> GetBySleeperIdAsync(string sleeperPlayerId, CancellationToken cancellationToken = default)
+        => await DbSet.AsNoTracking()
+            .FirstOrDefaultAsync(p => p.SleeperPlayerId == sleeperPlayerId, cancellationToken);
+
+    public async Task<IReadOnlyList<Player>> GetByPositionAsync(Position position, CancellationToken cancellationToken = default)
+        => await DbSet.AsNoTracking()
+            .Where(p => p.Position == position)
+            .OrderBy(p => p.LastName)
+            .ToListAsync(cancellationToken);
+
+    public async Task<IReadOnlyList<Player>> GetByNflTeamAsync(string nflTeam, CancellationToken cancellationToken = default)
+        => await DbSet.AsNoTracking()
+            .Where(p => p.NflTeam == nflTeam)
+            .OrderBy(p => p.Position)
+            .ThenBy(p => p.LastName)
+            .ToListAsync(cancellationToken);
+}

--- a/FF.Infrastructure/Persistence/SQL/Repositories/RosterRepository.cs
+++ b/FF.Infrastructure/Persistence/SQL/Repositories/RosterRepository.cs
@@ -1,0 +1,20 @@
+﻿using FF.Application.Interfaces.Persistence;
+using FF.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace FF.Infrastructure.Persistence.SQL.Repositories;
+
+public class RosterRepository : BaseRepository<Roster>, IRosterRepository
+{
+    public RosterRepository(FFDbContext context) : base(context) { }
+
+    public async Task<IReadOnlyList<Roster>> GetByLeagueIdAsync(Guid leagueId, CancellationToken cancellationToken = default)
+        => await DbSet.AsNoTracking()
+            .Where(r => r.LeagueId == leagueId)
+            .OrderBy(r => r.TeamName)
+            .ToListAsync(cancellationToken);
+
+    public async Task<Roster?> GetBySleeperRosterIdAsync(string sleeperRosterId, CancellationToken cancellationToken = default)
+        => await DbSet.AsNoTracking()
+            .FirstOrDefaultAsync(r => r.SleeperRosterId == sleeperRosterId, cancellationToken);
+}

--- a/FF.Infrastructure/Persistence/SQL/Repositories/UnitOfWork.cs
+++ b/FF.Infrastructure/Persistence/SQL/Repositories/UnitOfWork.cs
@@ -1,0 +1,34 @@
+﻿using FF.Application.Interfaces.Persistence;
+
+namespace FF.Infrastructure.Persistence.SQL.Repositories;
+
+public class UnitOfWork : IUnitOfWork
+{
+    private readonly FFDbContext _context;
+    private bool _disposed;
+
+    public IPlayerRepository Players { get; }
+    public ILeagueRepository Leagues { get; }
+    public IRosterRepository Rosters { get; }
+
+    public UnitOfWork(FFDbContext context)
+    {
+        _context = context;
+        Players = new PlayerRepository(context);
+        Leagues = new LeagueRepository(context);
+        Rosters = new RosterRepository(context);
+    }
+
+    public async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+        => await _context.SaveChangesAsync(cancellationToken);
+
+    public void Dispose()
+    {
+        if (!_disposed)
+        {
+            _context.Dispose();
+            _disposed = true;
+        }
+        GC.SuppressFinalize(this);
+    }
+}

--- a/FF.Tests/FF.Tests.csproj
+++ b/FF.Tests/FF.Tests.csproj
@@ -1,0 +1,38 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="8.8.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.13" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FF.Application\FF.Application.csproj" />
+    <ProjectReference Include="..\FF.Domain\FF.Domain.csproj" />
+    <ProjectReference Include="..\FF.Infrastructure\FF.Infrastructure.csproj" />
+    <ProjectReference Include="..\FF.SharedKernel\FF.SharedKernel.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Application\" />
+    <Folder Include="Domain\" />
+  </ItemGroup>
+
+</Project>

--- a/FF.Tests/Persistence/PlayerRepositoryTests.cs
+++ b/FF.Tests/Persistence/PlayerRepositoryTests.cs
@@ -1,0 +1,99 @@
+﻿using FF.Domain.Entities;
+using FF.Domain.Enums;
+using FF.Infrastructure.Persistence;
+using FF.Infrastructure.Persistence.SQL;
+using FF.Infrastructure.Persistence.SQL.Repositories;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+
+namespace FF.Tests.Persistence;
+
+public class PlayerRepositoryTests : IDisposable
+{
+    private readonly FFDbContext _context;
+    private readonly PlayerRepository _repository;
+
+    public PlayerRepositoryTests()
+    {
+        var options = new DbContextOptionsBuilder<FFDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString()) // unique per test class
+            .Options;
+
+        _context = new FFDbContext(options);
+        _repository = new PlayerRepository(_context);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ReturnsPlayer_WhenExists()
+    {
+        var player = Player.Create("Justin", "Jefferson", Position.WR, "MIN", "sleeper-123");
+        await _repository.AddAsync(player);
+        await _context.SaveChangesAsync();
+
+        var result = await _repository.GetByIdAsync(player.Id);
+
+        result.Should().NotBeNull();
+        result!.FullName.Should().Be("Justin Jefferson");
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ReturnsNull_WhenNotExists()
+    {
+        var result = await _repository.GetByIdAsync(Guid.NewGuid());
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetAllAsync_ReturnsAllPlayers()
+    {
+        await _repository.AddAsync(Player.Create("Patrick", "Mahomes", Position.QB, "KC", null));
+        await _repository.AddAsync(Player.Create("Tyreek", "Hill", Position.WR, "MIA", null));
+        await _context.SaveChangesAsync();
+
+        var result = await _repository.GetAllAsync();
+
+        result.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task GetByPositionAsync_ReturnsOnlyMatchingPosition()
+    {
+        await _repository.AddAsync(Player.Create("Patrick", "Mahomes", Position.QB, "KC", null));
+        await _repository.AddAsync(Player.Create("Josh", "Allen", Position.QB, "BUF", null));
+        await _repository.AddAsync(Player.Create("Tyreek", "Hill", Position.WR, "MIA", null));
+        await _context.SaveChangesAsync();
+
+        var result = await _repository.GetByPositionAsync(Position.QB);
+
+        result.Should().HaveCount(2);
+        result.Should().AllSatisfy(p => p.Position.Should().Be(Position.QB));
+    }
+
+    [Fact]
+    public async Task GetBySleeperIdAsync_ReturnsPlayer_WhenSleeperIdMatches()
+    {
+        await _repository.AddAsync(Player.Create("Justin", "Jefferson", Position.WR, "MIN", "sleeper-999"));
+        await _context.SaveChangesAsync();
+
+        var result = await _repository.GetBySleeperIdAsync("sleeper-999");
+
+        result.Should().NotBeNull();
+        result!.LastName.Should().Be("Jefferson");
+    }
+
+    [Fact]
+    public async Task Remove_DeletesPlayer()
+    {
+        var player = Player.Create("Player", "ToDelete", Position.K, "NE", null);
+        await _repository.AddAsync(player);
+        await _context.SaveChangesAsync();
+
+        _repository.Remove(player);
+        await _context.SaveChangesAsync();
+
+        var result = await _repository.GetByIdAsync(player.Id);
+        result.Should().BeNull();
+    }
+
+    public void Dispose() => _context.Dispose();
+}

--- a/FF.Tests/Persistence/UnitOfWorkTests.cs
+++ b/FF.Tests/Persistence/UnitOfWorkTests.cs
@@ -1,0 +1,55 @@
+﻿using FF.Domain.Entities;
+using FF.Domain.Enums;
+using FF.Infrastructure.Persistence;
+using FF.Infrastructure.Persistence.SQL;
+using FF.Infrastructure.Persistence.SQL.Repositories;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+
+namespace FF.Tests.Persistence;
+
+public class UnitOfWorkTests : IDisposable
+{
+    private readonly FFDbContext _context;
+    private readonly UnitOfWork _unitOfWork;
+
+    public UnitOfWorkTests()
+    {
+        var options = new DbContextOptionsBuilder<FFDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        _context = new FFDbContext(options);
+        _unitOfWork = new UnitOfWork(_context);
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_PersistsPlayerAddedViaUnitOfWork()
+    {
+        var player = Player.Create("CeeDee", "Lamb", Position.WR, "DAL", "sleeper-cdl");
+        await _unitOfWork.Players.AddAsync(player);
+        await _unitOfWork.SaveChangesAsync();
+
+        var result = await _unitOfWork.Players.GetByIdAsync(player.Id);
+        result.Should().NotBeNull();
+        result!.FullName.Should().Be("CeeDee Lamb");
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_PersistsLeagueAndRosterTogether()
+    {
+        var league = League.Create("Test League", "sleeper-league-1", 2025, 12);
+        await _unitOfWork.Leagues.AddAsync(league);
+        await _unitOfWork.SaveChangesAsync();
+
+        var roster = Roster.Create(league.Id, "Paul", "Paul's Team", "sleeper-roster-1");
+        await _unitOfWork.Rosters.AddAsync(roster);
+        await _unitOfWork.SaveChangesAsync();
+
+        var rosters = await _unitOfWork.Rosters.GetByLeagueIdAsync(league.Id);
+        rosters.Should().HaveCount(1);
+        rosters[0].TeamName.Should().Be("Paul's Team");
+    }
+
+    public void Dispose() => _unitOfWork.Dispose();
+}

--- a/FantasyFootball.sln
+++ b/FantasyFootball.sln
@@ -1,8 +1,7 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.0.0.0
+# Visual Studio Version 18
+VisualStudioVersion = 18.3.11520.95 d18.3
 MinimumVisualStudioVersion = 10.0.40219.1
-
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FF.SharedKernel", "FF.SharedKernel\FF.SharedKernel.csproj", "{D1A5C6E2-3B4F-4A92-9C2F-1A2B3C4D5E01}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FF.Domain", "FF.Domain\FF.Domain.csproj", "{D1A5C6E2-3B4F-4A92-9C2F-1A2B3C4D5E02}"
@@ -15,6 +14,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FF.API", "FF.API\FF.API.csp
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FF.WebBlazor", "FF.WebBlazor\FF.WebBlazor.csproj", "{D1A5C6E2-3B4F-4A92-9C2F-1A2B3C4D5E06}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FF.Tests", "FF.Tests\FF.Tests.csproj", "{31035E1D-CBBC-4C9D-A5A7-48612DD4823E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -25,33 +26,35 @@ Global
 		{D1A5C6E2-3B4F-4A92-9C2F-1A2B3C4D5E01}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D1A5C6E2-3B4F-4A92-9C2F-1A2B3C4D5E01}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D1A5C6E2-3B4F-4A92-9C2F-1A2B3C4D5E01}.Release|Any CPU.Build.0 = Release|Any CPU
-
 		{D1A5C6E2-3B4F-4A92-9C2F-1A2B3C4D5E02}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D1A5C6E2-3B4F-4A92-9C2F-1A2B3C4D5E02}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D1A5C6E2-3B4F-4A92-9C2F-1A2B3C4D5E02}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D1A5C6E2-3B4F-4A92-9C2F-1A2B3C4D5E02}.Release|Any CPU.Build.0 = Release|Any CPU
-
 		{D1A5C6E2-3B4F-4A92-9C2F-1A2B3C4D5E03}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D1A5C6E2-3B4F-4A92-9C2F-1A2B3C4D5E03}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D1A5C6E2-3B4F-4A92-9C2F-1A2B3C4D5E03}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D1A5C6E2-3B4F-4A92-9C2F-1A2B3C4D5E03}.Release|Any CPU.Build.0 = Release|Any CPU
-
 		{D1A5C6E2-3B4F-4A92-9C2F-1A2B3C4D5E04}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D1A5C6E2-3B4F-4A92-9C2F-1A2B3C4D5E04}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D1A5C6E2-3B4F-4A92-9C2F-1A2B3C4D5E04}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D1A5C6E2-3B4F-4A92-9C2F-1A2B3C4D5E04}.Release|Any CPU.Build.0 = Release|Any CPU
-
 		{D1A5C6E2-3B4F-4A92-9C2F-1A2B3C4D5E05}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D1A5C6E2-3B4F-4A92-9C2F-1A2B3C4D5E05}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D1A5C6E2-3B4F-4A92-9C2F-1A2B3C4D5E05}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D1A5C6E2-3B4F-4A92-9C2F-1A2B3C4D5E05}.Release|Any CPU.Build.0 = Release|Any CPU
-
 		{D1A5C6E2-3B4F-4A92-9C2F-1A2B3C4D5E06}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D1A5C6E2-3B4F-4A92-9C2F-1A2B3C4D5E06}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D1A5C6E2-3B4F-4A92-9C2F-1A2B3C4D5E06}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D1A5C6E2-3B4F-4A92-9C2F-1A2B3C4D5E06}.Release|Any CPU.Build.0 = Release|Any CPU
+		{31035E1D-CBBC-4C9D-A5A7-48612DD4823E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{31035E1D-CBBC-4C9D-A5A7-48612DD4823E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{31035E1D-CBBC-4C9D-A5A7-48612DD4823E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{31035E1D-CBBC-4C9D-A5A7-48612DD4823E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {7E4AF275-A4F5-428A-961C-23CD52B417DA}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
Implements the repository pattern and Unit of Work for SQL Server 
data access in FF.Infrastructure, with interfaces defined in 
FF.Application per Clean Architecture rules.

## Changes
- IRepository<T> + 3 entity-specific interfaces in FF.Application
- IUnitOfWork interface in FF.Application
- BaseRepository<T> + 3 concrete implementations in FF.Infrastructure
- UnitOfWork implementation in FF.Infrastructure
- DI registrations in FF.API/Program.cs
- FF.Tests project created with 9 passing unit tests

## Test Results
✅ 9/9 tests passing

## Notes
- InMemory provider used for unit tests — filtered unique indexes 
  not enforced at this level (by design)
- Integration tests against LINUXSERVER SQL Server deferred to Phase 6
- FluentAssertions pinned to 6.12.2 (v7 license breaking change)

## Backlog
Closes PBI-006 | Next: PBI-007 (MediatR pipeline behaviors)