### PR TITLE
feat: PBI-021 usage metric aggregation pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -492,3 +492,4 @@ $RECYCLE.BIN/
 
 # Vim temporary swap files
 *.swp
+/create_github_issues.sh

--- a/FF.API/Controllers/UsageMetricsController.cs
+++ b/FF.API/Controllers/UsageMetricsController.cs
@@ -1,0 +1,43 @@
+﻿// FF.API/Controllers/UsageMetricsController.cs
+using FF.Application.Interfaces.Persistence;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FF.API.Controllers;
+
+[ApiController]
+[Route("api/v1/players")]
+[Authorize]
+public class UsageMetricsController(IUsageMetricsRepository repository) : ControllerBase
+{
+    private readonly IUsageMetricsRepository _repository = repository;
+
+    // GET /api/v1/players/{playerId}/usage?season=2024
+    [HttpGet("{playerId}/usage")]
+    public async Task<IActionResult> GetUsageMetrics(
+        string playerId,
+        [FromQuery] int season = 2024,
+        CancellationToken ct = default)
+    {
+        var metrics = await _repository
+            .GetByPlayerSeasonAsync(playerId, season, ct);
+
+        if (metrics is null)
+            return NotFound(new { message = $"No usage metrics found for player {playerId} season {season}" });
+
+        return Ok(metrics);
+    }
+
+    // GET /api/v1/players/usage?season=2024&position=WR
+    [HttpGet("usage")]
+    public async Task<IActionResult> GetUsageMetricsBySeason(
+        [FromQuery] int season = 2024,
+        [FromQuery] string? position = null,
+        CancellationToken ct = default)
+    {
+        var metrics = await _repository
+            .GetBySeasonAsync(season, position, ct);
+
+        return Ok(metrics);
+    }
+}

--- a/FF.API/Program.cs
+++ b/FF.API/Program.cs
@@ -98,8 +98,7 @@ try
 
     var app = builder.Build();
 
-    await DatabaseInitialiser.InitialiseAsync(app.Services);
-    
+   
     // ── MIDDLEWARE PIPELINE ───────────────────────────────
     // Order matters — do not rearrange without understanding the implications
     app.UseMiddleware<ExceptionHandlingMiddleware>();
@@ -150,7 +149,6 @@ try
     }
 
     // ── STARTUP TASKS ─────────────────────────────────────
-    // DatabaseInitialiser runs migrations + seed on every startup (idempotent)
     await DatabaseInitialiser.InitialiseAsync(app.Services);
 
     // MongoDB index creation — idempotent, safe to run on every startup
@@ -187,6 +185,12 @@ try
         recurringJobId: "weekly-stats-sync",
         methodCall: x => x.SyncCurrentSeasonAsync(),
         cronExpression: Cron.Weekly(DayOfWeek.Tuesday, 8),
+        options: utcOptions);
+
+    RecurringJob.AddOrUpdate<UsageMetricsAggregationJob>(
+        recurringJobId: "usage-metrics-aggregation",
+        methodCall: job => job.ExecuteAsync(2024),
+        cronExpression: Cron.Weekly(DayOfWeek.Tuesday, 6),
         options: utcOptions);
 
     //RecurringJob.AddOrUpdate<WaiverSyncJob>(

--- a/FF.Application/FF.Application.csproj
+++ b/FF.Application/FF.Application.csproj
@@ -14,4 +14,8 @@
     <ProjectReference Include="..\FF.SharedKernel\FF.SharedKernel.csproj" />
     <ProjectReference Include="..\FF.Domain\FF.Domain.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Interfaces\Repositories\" />
+    <Folder Include="Services\" />
+  </ItemGroup>
 </Project>

--- a/FF.Application/Interfaces/Persistence/IPlayerGameLogRepository.cs
+++ b/FF.Application/Interfaces/Persistence/IPlayerGameLogRepository.cs
@@ -21,6 +21,15 @@ public interface IPlayerGameLogRepository
         int week,
         CancellationToken cancellationToken = default);
 
+    Task<List<PlayerGameLogDocument>> GetByPlayerSeasonAsync(
+    string playerId,
+    int season,
+    CancellationToken cancellationToken = default);
+
+    Task<List<string>> GetDistinctPlayerIdsAsync(
+        int season,
+        CancellationToken cancellationToken = default);
+
     Task<long> DeleteSeasonAsync(
         int season,
         CancellationToken cancellationToken = default);

--- a/FF.Application/Interfaces/Persistence/ISnapCountRepository.cs
+++ b/FF.Application/Interfaces/Persistence/ISnapCountRepository.cs
@@ -1,0 +1,18 @@
+﻿// FF.Application/Interfaces/Persistence/ISnapCountRepository.cs
+using FF.Domain.Documents;
+
+namespace FF.Application.Interfaces.Persistence;
+
+public interface ISnapCountRepository
+{
+    Task<(int Inserted, int Replaced)> UpsertBatchAsync(
+        IEnumerable<SnapCountDocument> documents,
+        CancellationToken cancellationToken = default);
+
+    Task<List<SnapCountDocument>> GetBySeasonWeekAsync(
+        int season,
+        int week,
+        CancellationToken cancellationToken = default);
+
+    Task EnsureIndexesAsync();
+}

--- a/FF.Application/Interfaces/Persistence/IUsageMetricsRepository.cs
+++ b/FF.Application/Interfaces/Persistence/IUsageMetricsRepository.cs
@@ -1,0 +1,21 @@
+﻿// FF.Application/Interfaces/Persistence/IUsageMetricsRepository.cs
+using FF.Domain.Documents;
+
+namespace FF.Application.Interfaces.Persistence;
+
+public interface IUsageMetricsRepository
+{
+    Task<PlayerUsageMetricsDocument?> GetByPlayerSeasonAsync(
+        string playerId,
+        int season,
+        CancellationToken ct = default);
+
+    Task UpsertAsync(
+        PlayerUsageMetricsDocument metrics,
+        CancellationToken ct = default);
+
+    Task<IReadOnlyList<PlayerUsageMetricsDocument>> GetBySeasonAsync(
+        int season,
+        string? position = null,
+        CancellationToken ct = default);
+}

--- a/FF.Application/Interfaces/Services/INflverseDownloadService.cs
+++ b/FF.Application/Interfaces/Services/INflverseDownloadService.cs
@@ -1,6 +1,7 @@
 ﻿// FF.Application/Interfaces/Services/INflverseDownloadService.cs
 namespace FF.Application.Interfaces.Services;
 
+
 public interface INflverseDownloadService
 {
     /// <summary>
@@ -8,6 +9,10 @@ public interface INflverseDownloadService
     /// Saves to the configured HistoricalData.BasePath for subsequent import.
     /// </summary>
     Task<NflverseDownloadResult> DownloadCurrentSeasonAsync(
+        int season,
+        CancellationToken cancellationToken = default);
+
+    Task<NflverseDownloadResult> DownloadSnapCountsAsync(
         int season,
         CancellationToken cancellationToken = default);
 }

--- a/FF.Application/Interfaces/Services/Usage/IUsageMetricsService.cs
+++ b/FF.Application/Interfaces/Services/Usage/IUsageMetricsService.cs
@@ -1,0 +1,13 @@
+﻿namespace FF.Application.Interfaces.Services.Usage;
+
+public interface IUsageMetricsService
+{
+    Task AggregatePlayerMetricsAsync(
+        string playerId,
+        int season,                    // int not string
+        CancellationToken ct = default);
+
+    Task AggregateAllPlayersAsync(
+        int season,                    // int not string
+        CancellationToken ct = default);
+}

--- a/FF.Application/Interfaces/Services/Usage/UsageMetricsCalculator.cs
+++ b/FF.Application/Interfaces/Services/Usage/UsageMetricsCalculator.cs
@@ -1,0 +1,27 @@
+﻿// FF.Application/Services/Usage/UsageMetricsCalculator.cs
+namespace FF.Application.Interfaces.Services.Usage;
+
+public static class UsageMetricsCalculator
+{
+    // Weighted rolling average — most recent week gets highest weight
+    // weights = [3, 2, 1] for 3-week, [5, 4, 3, 2, 1] for 5-week
+    public static decimal WeightedAverage(IList<decimal> values, int window)
+    {
+        var slice = values.TakeLast(window).ToList();
+        if (slice.Count == 0) return 0m;
+
+        var weights = Enumerable.Range(1, slice.Count).Select(i => (decimal)i).ToList();
+        var weightedSum = slice.Zip(weights, (v, w) => v * w).Sum();
+        var weightTotal = weights.Sum();
+
+        return Math.Round(weightTotal == 0 ? 0m : weightedSum / weightTotal, 4);
+    }
+
+    // WOPR = (TargetShare * 1.5) + (AirYardsShare * 0.7)
+    // Standard nflfastR definition
+    public static decimal CalculateWopr(decimal targetShare, decimal airYardsShare)
+        => (targetShare * 1.5m) + (airYardsShare * 0.7m);
+
+    public static decimal SimpleAverage(IList<decimal> values)
+        => values.Any() ? Math.Round(values.Average(), 4) : 0m;
+}

--- a/FF.Domain/Documents/PlayerGameLogDocument.cs
+++ b/FF.Domain/Documents/PlayerGameLogDocument.cs
@@ -96,4 +96,10 @@ public class PlayerGameLogDocument
     public decimal? PfrFantasyPoints { get; set; }             // PFR's fantasy point total
     public decimal? PfrVariance { get; set; }                  // difference vs nflfastR
     public DateTime ImportedAt { get; set; } = DateTime.UtcNow;
+
+    // ── Snap Count Data ───────────────────────────────────────────────────
+    // Sourced from nflverse snap_counts dataset (PFR data)
+    // Populated by SnapCountImportJob — separate from main game log import
+    public int OffenseSnaps { get; set; }       // raw snap count
+    public decimal SnapPct { get; set; }        // offense_pct (0.0 to 1.0)
 }

--- a/FF.Domain/Documents/PlayerUsageMetricDocument.cs
+++ b/FF.Domain/Documents/PlayerUsageMetricDocument.cs
@@ -1,0 +1,39 @@
+﻿// FF.Domain/Documents/PlayerUsageMetricsDocument.cs
+namespace FF.Domain.Documents;
+
+public class PlayerUsageMetricsDocument
+{
+    public string? Id { get; set; }
+    public string PlayerId { get; set; } = string.Empty;
+    public int Season { get; set; }
+    public string Position { get; set; } = string.Empty;
+
+    // Target Share rolling averages
+    public decimal TargetShare3Wk { get; set; }
+    public decimal TargetShare5Wk { get; set; }
+    public decimal TargetShareSeason { get; set; }
+
+    // Snap % rolling averages
+    // NOTE: SnapPct is not on PlayerGameLogDocument yet — see note below
+    public decimal SnapPct3Wk { get; set; }
+    public decimal SnapPct5Wk { get; set; }
+    public decimal SnapPctSeason { get; set; }
+
+    // Air Yards Share rolling averages
+    public decimal AirYardsShare3Wk { get; set; }
+    public decimal AirYardsShare5Wk { get; set; }
+    public decimal AirYardsShareSeason { get; set; }
+
+    // Carry Share rolling averages (RB primary, others near zero)
+    public decimal CarryShare3Wk { get; set; }
+    public decimal CarryShare5Wk { get; set; }
+    public decimal CarryShareSeason { get; set; }
+
+    // WOPR rolling averages — averaged from existing Wopr on game logs
+    public decimal Wopr3Wk { get; set; }
+    public decimal WoprSeason { get; set; }
+
+    public int WeeksPlayed { get; set; }
+    public int LastWeekProcessed { get; set; }
+    public DateTime LastUpdated { get; set; }
+}

--- a/FF.Domain/Documents/SnapCountDocument.cs
+++ b/FF.Domain/Documents/SnapCountDocument.cs
@@ -1,0 +1,15 @@
+﻿namespace FF.Domain.Documents;
+
+public class SnapCountDocument
+{
+    public string? Id { get; set; }
+    public string PfrPlayerId { get; set; } = string.Empty;
+    public string PlayerName { get; set; } = string.Empty;
+    public string Position { get; set; } = string.Empty;
+    public string Team { get; set; } = string.Empty;
+    public int Season { get; set; }
+    public int Week { get; set; }
+    public int OffenseSnaps { get; set; }
+    public decimal OffensePct { get; set; }
+    public DateTime ImportedAt { get; set; } = DateTime.UtcNow;
+}

--- a/FF.Infrastructure/DependencyInjection.cs
+++ b/FF.Infrastructure/DependencyInjection.cs
@@ -4,7 +4,7 @@ using FF.Application.Interfaces.Auth;
 using FF.Application.Interfaces.Jobs;
 using FF.Application.Interfaces.Persistence;
 using FF.Application.Interfaces.Services;
-using FF.Application.Stats.Commands;
+using FF.Application.Interfaces.Services.Usage;
 using FF.Domain.Documents;
 using FF.Infrastructure.ExternalApis.CsvImport;
 using FF.Infrastructure.ExternalApis.CsvImport.Parsers;
@@ -54,6 +54,10 @@ public static class DependencyInjection
         services.AddScoped<ILeagueRepository, LeagueRepository>();
         services.AddScoped<IRosterRepository, RosterRepository>();
         services.AddScoped<IPlayerGameLogRepository, PlayerGameLogRepository>();
+        services.AddScoped<IUsageMetricsRepository, UsageMetricsRepository>();
+        services.AddScoped<ISnapCountRepository, SnapCountRepository>();
+        services.AddScoped<IUsageMetricsService, UsageMetricsService>();
+        services.AddScoped<UsageMetricsAggregationJob>();
 
         // Add named HttpClient for nflverse — GitHub redirects require following redirects
         services.AddHttpClient<NflverseDownloadService>(client =>
@@ -129,15 +133,76 @@ public static class DependencyInjection
 
     private static void RegisterBsonClassMaps()
     {
-        if (!BsonClassMap.IsClassMapRegistered(typeof(PlayerGameLogDocument)))
+        try
         {
-            BsonClassMap.RegisterClassMap<PlayerGameLogDocument>(cm =>
+            var decimalSerializer = new DecimalSerializer(BsonType.Decimal128);
+
+            if (!BsonClassMap.IsClassMapRegistered(typeof(PlayerUsageMetricsDocument)))
             {
-                cm.AutoMap();
-                cm.MapIdMember(c => c.Id)
-                  .SetIdGenerator(StringObjectIdGenerator.Instance)
-                  .SetSerializer(new StringSerializer(BsonType.ObjectId));
-            });
+                System.Diagnostics.Debug.WriteLine("Registering PlayerUsageMetricsDocument...");
+                BsonClassMap.RegisterClassMap<PlayerUsageMetricsDocument>(cm =>
+                {
+                    cm.AutoMap();
+                    cm.SetIgnoreExtraElements(true);
+                    cm.MapIdMember(c => c.Id)
+                      .SetIdGenerator(StringObjectIdGenerator.Instance)
+                      .SetSerializer(new StringSerializer(BsonType.ObjectId));
+
+                    cm.MapMember(c => c.TargetShare3Wk).SetSerializer(decimalSerializer);
+                    cm.MapMember(c => c.TargetShare5Wk).SetSerializer(decimalSerializer);
+                    cm.MapMember(c => c.TargetShareSeason).SetSerializer(decimalSerializer);
+                    cm.MapMember(c => c.SnapPct3Wk).SetSerializer(decimalSerializer);
+                    cm.MapMember(c => c.SnapPct5Wk).SetSerializer(decimalSerializer);
+                    cm.MapMember(c => c.SnapPctSeason).SetSerializer(decimalSerializer);
+                    cm.MapMember(c => c.AirYardsShare3Wk).SetSerializer(decimalSerializer);
+                    cm.MapMember(c => c.AirYardsShare5Wk).SetSerializer(decimalSerializer);
+                    cm.MapMember(c => c.AirYardsShareSeason).SetSerializer(decimalSerializer);
+                    cm.MapMember(c => c.CarryShare3Wk).SetSerializer(decimalSerializer);
+                    cm.MapMember(c => c.CarryShare5Wk).SetSerializer(decimalSerializer);
+                    cm.MapMember(c => c.CarryShareSeason).SetSerializer(decimalSerializer);
+                    cm.MapMember(c => c.Wopr3Wk).SetSerializer(decimalSerializer);
+                    cm.MapMember(c => c.WoprSeason).SetSerializer(decimalSerializer);
+                });
+                System.Diagnostics.Debug.WriteLine("PlayerUsageMetricsDocument registered OK");
+            }
+
+            if (!BsonClassMap.IsClassMapRegistered(typeof(PlayerGameLogDocument)))
+            {
+                BsonClassMap.RegisterClassMap<PlayerGameLogDocument>(cm =>
+                {
+                    cm.AutoMap();
+                    cm.SetIgnoreExtraElements(true);
+                    cm.MapIdMember(c => c.Id)
+                      .SetIdGenerator(StringObjectIdGenerator.Instance)
+                      .SetSerializer(new StringSerializer(BsonType.ObjectId));
+                });
+            }
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"FAILED PlayerUsageMetricsDocument: {ex.Message}");
+            throw;
+        }
+
+        try
+        {
+            if (!BsonClassMap.IsClassMapRegistered(typeof(SnapCountDocument)))
+            {
+                System.Diagnostics.Debug.WriteLine("Registering SnapCountDocument...");
+                BsonClassMap.RegisterClassMap<SnapCountDocument>(cm =>
+                {
+                    cm.AutoMap();
+                    cm.MapIdMember(c => c.Id)
+                      .SetIdGenerator(StringObjectIdGenerator.Instance)
+                      .SetSerializer(new StringSerializer(BsonType.ObjectId));
+                });
+                System.Diagnostics.Debug.WriteLine("SnapCountDocument registered OK");
+            }
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"FAILED SnapCountDocument: {ex.Message}");
+            throw;
         }
     }
 }

--- a/FF.Infrastructure/ExternalAPIs/Nflverse/NflverseDownloadService.cs
+++ b/FF.Infrastructure/ExternalAPIs/Nflverse/NflverseDownloadService.cs
@@ -72,4 +72,60 @@ public class NflverseDownloadService(
             };
         }
     }
+
+    private const string SnapCountsBaseUrl =
+    "https://github.com/nflverse/nflverse-data/releases/download/snap_counts";
+
+    public async Task<NflverseDownloadResult> DownloadSnapCountsAsync(
+        int season,
+        CancellationToken cancellationToken = default)
+    {
+        var startedAt = DateTime.UtcNow;
+        var url = $"{SnapCountsBaseUrl}/snap_counts_{season}.csv";
+        var savePath = Path.Combine(
+            _settings.BasePath, "nflfastr", $"snap_counts_{season}.csv");
+
+        _logger.LogInformation(
+            "Downloading nflverse snap counts for season {Season} from {Url}",
+            season, url);
+
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(savePath)!);
+
+            var response = await _httpClient.GetAsync(url, cancellationToken);
+            response.EnsureSuccessStatusCode();
+
+            var bytes = await response.Content.ReadAsByteArrayAsync(cancellationToken);
+            await File.WriteAllBytesAsync(savePath, bytes, cancellationToken);
+
+            var duration = DateTime.UtcNow - startedAt;
+
+            _logger.LogInformation(
+                "Downloaded snap_counts_{Season}.csv — {Size:N0} bytes in {Duration}",
+                season, bytes.Length, duration);
+
+            return new NflverseDownloadResult
+            {
+                Success = true,
+                Season = season,
+                SavedPath = savePath,
+                FileSizeBytes = bytes.Length,
+                Duration = duration
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Failed to download nflverse snap counts for season {Season}", season);
+
+            return new NflverseDownloadResult
+            {
+                Success = false,
+                Season = season,
+                ErrorMessage = ex.Message,
+                Duration = DateTime.UtcNow - startedAt
+            };
+        }
+    }
 }

--- a/FF.Infrastructure/Jobs/UsageMetricsAggregationJob.cs
+++ b/FF.Infrastructure/Jobs/UsageMetricsAggregationJob.cs
@@ -1,0 +1,24 @@
+﻿// FF.Infrastructure/Jobs/UsageMetricsAggregationJob.cs
+using FF.Application.Interfaces.Services.Usage;
+using Microsoft.Extensions.Logging;
+
+namespace FF.Infrastructure.Jobs;
+
+public class UsageMetricsAggregationJob(
+    IUsageMetricsService usageMetricsService,
+    ILogger<UsageMetricsAggregationJob> logger)
+{
+    private readonly IUsageMetricsService _usageMetricsService = usageMetricsService;
+    private readonly ILogger<UsageMetricsAggregationJob> _logger = logger;
+
+    public async Task ExecuteAsync(int season)
+    {
+        _logger.LogInformation(
+            "UsageMetricsAggregationJob started for season {Season}", season);
+
+        await _usageMetricsService.AggregateAllPlayersAsync(season);
+
+        _logger.LogInformation(
+            "UsageMetricsAggregationJob completed for season {Season}", season);
+    }
+}

--- a/FF.Infrastructure/Persistence/Mongo/Repositories/PlayerGameLogRepository.cs
+++ b/FF.Infrastructure/Persistence/Mongo/Repositories/PlayerGameLogRepository.cs
@@ -14,6 +14,7 @@
 //   Filter: PlayerId + Season + Week (the natural unique key from nflfastR).
 //   This makes the import fully idempotent — re-running the same file is safe.
 
+using FF.Application.Interfaces.Persistence;
 using FF.Domain.Documents;
 using Microsoft.Extensions.Logging;
 using MongoDB.Bson;
@@ -22,7 +23,7 @@ using System.Diagnostics.Metrics;
 
 namespace FF.Infrastructure.Persistence.Mongo.Repositories;
 
-public class PlayerGameLogRepository(MongoDbContext context, ILogger<PlayerGameLogRepository> logger) : FF.Application.Interfaces.Persistence.IPlayerGameLogRepository
+public class PlayerGameLogRepository(MongoDbContext context, ILogger<PlayerGameLogRepository> logger) : IPlayerGameLogRepository
 {
     private readonly IMongoCollection<PlayerGameLogDocument> _collection = context.Database.GetCollection<PlayerGameLogDocument>(CollectionName);
     private readonly ILogger<PlayerGameLogRepository> _logger = logger;
@@ -257,5 +258,28 @@ public class PlayerGameLogRepository(MongoDbContext context, ILogger<PlayerGameL
         var filter = Builders<PlayerGameLogDocument>.Filter.Eq(x => x.Season, season);
         var result = await _collection.DeleteManyAsync(filter, cancellationToken);
         return result.DeletedCount;
+    }
+
+    public async Task<List<PlayerGameLogDocument>> GetByPlayerSeasonAsync(
+    string playerId,
+    int season,
+    CancellationToken cancellationToken = default)
+    {
+        return await _collection
+            .Find(x => x.PlayerId == playerId && x.Season == season)
+            .SortBy(x => x.Week)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<List<string>> GetDistinctPlayerIdsAsync(
+        int season,
+        CancellationToken cancellationToken = default)
+    {
+        var filter = Builders<PlayerGameLogDocument>.Filter
+            .Eq(x => x.Season, season);
+
+        return await _collection
+            .Distinct(x => x.PlayerId, filter, cancellationToken: cancellationToken)
+            .ToListAsync(cancellationToken);
     }
 }

--- a/FF.Infrastructure/Persistence/Mongo/Repositories/SnapCountRepository.cs
+++ b/FF.Infrastructure/Persistence/Mongo/Repositories/SnapCountRepository.cs
@@ -1,0 +1,78 @@
+﻿// FF.Infrastructure/Persistence/Mongo/Repositories/SnapCountRepository.cs
+using FF.Application.Interfaces.Persistence;
+using FF.Domain.Documents;
+using Microsoft.Extensions.Logging;
+using MongoDB.Driver;
+
+namespace FF.Infrastructure.Persistence.Mongo.Repositories;
+
+public class SnapCountRepository(MongoDbContext database,
+    ILogger<SnapCountRepository> logger) : ISnapCountRepository
+{
+    private readonly IMongoCollection<SnapCountDocument> _collection =
+        database.GetCollection<SnapCountDocument>("snap_counts");
+
+    public async Task EnsureIndexesAsync()
+    {
+        var indexes = new List<CreateIndexModel<SnapCountDocument>>
+        {
+            // Season + Week — bulk weekly queries
+            new(Builders<SnapCountDocument>.IndexKeys
+                .Ascending(x => x.Season)
+                .Ascending(x => x.Week)),
+
+            // Name + Team + Season + Week — merge lookup key
+            // Not unique — same player can appear on multiple teams in a season
+            new(Builders<SnapCountDocument>.IndexKeys
+                .Ascending(x => x.PlayerName)
+                .Ascending(x => x.Team)
+                .Ascending(x => x.Season)
+                .Ascending(x => x.Week)),
+        };
+
+        await _collection.Indexes.CreateManyAsync(indexes);
+
+        logger.LogInformation("SnapCountRepository indexes ensured");
+    }
+
+    public async Task<(int Inserted, int Replaced)> UpsertBatchAsync(
+        IEnumerable<SnapCountDocument> documents,
+        CancellationToken cancellationToken = default)
+    {
+        var docs = documents.ToList();
+        if (docs.Count == 0) return (0, 0);
+
+        var inserted = 0;
+        var replaced = 0;
+
+        foreach (var doc in docs)
+        {
+            var filter = Builders<SnapCountDocument>.Filter.Where(x =>
+                x.PlayerName == doc.PlayerName &&
+                x.Team == doc.Team &&
+                x.Season == doc.Season &&
+                x.Week == doc.Week);
+
+            var result = await _collection.ReplaceOneAsync(
+                filter,
+                doc,
+                new ReplaceOptions { IsUpsert = true },
+                cancellationToken);
+
+            if (result.MatchedCount == 0) inserted++;
+            else replaced++;
+        }
+
+        return (inserted, replaced);
+    }
+
+    public async Task<List<SnapCountDocument>> GetBySeasonWeekAsync(
+        int season,
+        int week,
+        CancellationToken cancellationToken = default)
+    {
+        return await _collection
+            .Find(x => x.Season == season && x.Week == week)
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/FF.Infrastructure/Persistence/Mongo/Repositories/UsageMetricsRepository.cs
+++ b/FF.Infrastructure/Persistence/Mongo/Repositories/UsageMetricsRepository.cs
@@ -1,0 +1,79 @@
+﻿// FF.Infrastructure/Persistence/MongoDB/Repositories/UsageMetricsRepository.cs
+using FF.Application.Interfaces.Persistence;
+using FF.Domain.Documents;
+using MongoDB.Driver;
+
+namespace FF.Infrastructure.Persistence.Mongo.Repositories;
+
+public class UsageMetricsRepository : IUsageMetricsRepository
+{
+    private readonly IMongoCollection<PlayerUsageMetricsDocument> _collection;
+
+    public UsageMetricsRepository(MongoDbContext database)
+    {
+        _collection = database.GetCollection<PlayerUsageMetricsDocument>(
+            "player_usage_metrics");
+
+        // Ensure unique composite index on playerId + season
+        var indexKeys = Builders<PlayerUsageMetricsDocument>.IndexKeys
+            .Ascending(x => x.PlayerId)
+            .Ascending(x => x.Season);
+
+        var indexOptions = new CreateIndexOptions { Unique = true };
+        _collection.Indexes.CreateOne(
+            new CreateIndexModel<PlayerUsageMetricsDocument>(indexKeys, indexOptions));
+    }
+
+    public async Task<PlayerUsageMetricsDocument?> GetByPlayerSeasonAsync(
+        string playerId, int season, CancellationToken ct = default)
+    {
+        return await _collection
+            .Find(x => x.PlayerId == playerId && x.Season == season)
+            .FirstOrDefaultAsync(ct);
+    }
+    public async Task UpsertAsync(
+        PlayerUsageMetricsDocument metrics,
+        CancellationToken ct = default)
+    {
+        var filter = Builders<PlayerUsageMetricsDocument>.Filter
+            .Where(x => x.PlayerId == metrics.PlayerId && x.Season == metrics.Season);
+
+        var update = Builders<PlayerUsageMetricsDocument>.Update
+            .Set(x => x.Position, metrics.Position)
+            .Set(x => x.TargetShare3Wk, metrics.TargetShare3Wk)
+            .Set(x => x.TargetShare5Wk, metrics.TargetShare5Wk)
+            .Set(x => x.TargetShareSeason, metrics.TargetShareSeason)
+            .Set(x => x.SnapPct3Wk, metrics.SnapPct3Wk)
+            .Set(x => x.SnapPct5Wk, metrics.SnapPct5Wk)
+            .Set(x => x.SnapPctSeason, metrics.SnapPctSeason)
+            .Set(x => x.AirYardsShare3Wk, metrics.AirYardsShare3Wk)
+            .Set(x => x.AirYardsShare5Wk, metrics.AirYardsShare5Wk)
+            .Set(x => x.AirYardsShareSeason, metrics.AirYardsShareSeason)
+            .Set(x => x.CarryShare3Wk, metrics.CarryShare3Wk)
+            .Set(x => x.CarryShare5Wk, metrics.CarryShare5Wk)
+            .Set(x => x.CarryShareSeason, metrics.CarryShareSeason)
+            .Set(x => x.Wopr3Wk, metrics.Wopr3Wk)
+            .Set(x => x.WoprSeason, metrics.WoprSeason)
+            .Set(x => x.WeeksPlayed, metrics.WeeksPlayed)
+            .Set(x => x.LastWeekProcessed, metrics.LastWeekProcessed)
+            .Set(x => x.LastUpdated, metrics.LastUpdated);
+
+        await _collection.UpdateOneAsync(
+            filter,
+            update,
+            new UpdateOptions { IsUpsert = true }, ct);
+    }
+
+    public async Task<IReadOnlyList<PlayerUsageMetricsDocument>> GetBySeasonAsync(
+        int season, string? position = null, CancellationToken ct = default)
+    {
+        var filter = Builders<PlayerUsageMetricsDocument>.Filter
+            .Eq(x => x.Season, season);
+
+        if (!string.IsNullOrEmpty(position))
+            filter &= Builders<PlayerUsageMetricsDocument>.Filter
+                .Eq(x => x.Position, position);
+
+        return await _collection.Find(filter).ToListAsync(ct);
+    }
+}

--- a/FF.Infrastructure/Services/UsageMetricsService.cs
+++ b/FF.Infrastructure/Services/UsageMetricsService.cs
@@ -1,0 +1,105 @@
+﻿// FF.Infrastructure/Services/UsageMetricsService.cs
+using FF.Application.Interfaces.Persistence;
+using FF.Application.Interfaces.Services.Usage;
+using FF.Domain.Documents;
+using Microsoft.Extensions.Logging;
+
+namespace FF.Infrastructure.Services;
+
+public class UsageMetricsService(
+    IPlayerGameLogRepository gameLogRepository,
+    IUsageMetricsRepository metricsRepository,
+    ILogger<UsageMetricsService> logger) : IUsageMetricsService
+{
+    private readonly IPlayerGameLogRepository _gameLogRepository = gameLogRepository;
+    private readonly IUsageMetricsRepository _metricsRepository = metricsRepository;
+    private readonly ILogger<UsageMetricsService> _logger = logger;
+
+    public async Task AggregatePlayerMetricsAsync(
+        string playerId,
+        int season,
+        CancellationToken ct = default)
+    {
+        var gameLogs = await _gameLogRepository
+            .GetByPlayerSeasonAsync(playerId, season, ct);
+
+        // Exclude weeks where the player had zero snaps (DNP / inactive)
+        // SnapPct not yet on document — using Targets + Carries as proxy for active
+        var activeLogs = gameLogs
+            .Where(g => g.Targets > 0 || g.Carries > 0 ||
+                        g.Completions > 0 || g.SpecialTeamsTds > 0)
+            .OrderBy(g => g.Week)
+            .ToList();
+
+        if (activeLogs.Count == 0)
+        {
+            _logger.LogDebug(
+                "No active game logs for player {PlayerId} season {Season}",
+                playerId, season);
+            return;
+        }
+
+        var targetShares = activeLogs.Select(g => g.TargetShare).ToList();
+        var airYardsShares = activeLogs.Select(g => g.AirYardsShare).ToList();
+        var woprs = activeLogs.Select(g => g.Wopr).ToList();
+
+        // CarryShare: Carries / team total carries not on document yet
+        // Store raw carries for now — will refine when snap/team data added
+        var carryShares = activeLogs
+            .Select(g => g.Carries > 0 ? (decimal)g.Carries : 0m)
+            .ToList();
+
+        var metrics = new PlayerUsageMetricsDocument
+        {
+            PlayerId = playerId,
+            Season = season,
+            Position = activeLogs.Last().Position,
+
+            TargetShare3Wk = UsageMetricsCalculator.WeightedAverage(targetShares, 3),
+            TargetShare5Wk = UsageMetricsCalculator.WeightedAverage(targetShares, 5),
+            TargetShareSeason = UsageMetricsCalculator.SimpleAverage(targetShares),
+
+            AirYardsShare3Wk = UsageMetricsCalculator.WeightedAverage(airYardsShares, 3),
+            AirYardsShare5Wk = UsageMetricsCalculator.WeightedAverage(airYardsShares, 5),
+            AirYardsShareSeason = UsageMetricsCalculator.SimpleAverage(airYardsShares),
+
+            CarryShare3Wk = UsageMetricsCalculator.WeightedAverage(carryShares, 3),
+            CarryShare5Wk = UsageMetricsCalculator.WeightedAverage(carryShares, 5),
+            CarryShareSeason = UsageMetricsCalculator.SimpleAverage(carryShares),
+
+            Wopr3Wk = UsageMetricsCalculator.WeightedAverage(woprs, 3),
+            WoprSeason = UsageMetricsCalculator.SimpleAverage(woprs),
+
+            WeeksPlayed = activeLogs.Count,
+            LastWeekProcessed = activeLogs.Last().Week,
+            LastUpdated = DateTime.UtcNow
+        };
+
+        await _metricsRepository.UpsertAsync(metrics, ct);
+
+        _logger.LogInformation(
+            "Aggregated usage metrics for {PlayerId} season {Season} — {Weeks} weeks",
+            playerId, season, activeLogs.Count);
+    }
+
+    public async Task AggregateAllPlayersAsync(
+        int season,
+        CancellationToken ct = default)
+    {
+        var playerIds = await _gameLogRepository
+            .GetDistinctPlayerIdsAsync(season, ct);
+
+        _logger.LogInformation(
+            "Starting usage aggregation for {Count} players — season {Season}",
+            playerIds.Count, season);
+
+        foreach (var batch in playerIds.Chunk(10))
+        {
+            await Task.WhenAll(
+                batch.Select(id => AggregatePlayerMetricsAsync(id, season, ct)));
+        }
+
+        _logger.LogInformation(
+            "Completed usage aggregation for season {Season}", season);
+    }
+}

--- a/FF.Tests/Unit/Services/UsageMetricCalculatorTests.cs
+++ b/FF.Tests/Unit/Services/UsageMetricCalculatorTests.cs
@@ -1,0 +1,63 @@
+﻿// FF.Tests/Unit/Services/UsageMetricsCalculatorTests.cs
+using FF.Application.Interfaces.Services.Usage;
+
+namespace FF.Tests.Unit.Services;
+
+public class UsageMetricsCalculatorTests
+{
+    [Fact]
+    public void WeightedAverage_3Week_AppliesCorrectWeights()
+    {
+        // Arrange — weeks 1,2,3 with values 0.10, 0.20, 0.30
+        // Weights: week1=1, week2=2, week3=3
+        // Expected: (0.10*1 + 0.20*2 + 0.30*3) / (1+2+3) = 1.40/6 = 0.2333
+        var values = new List<decimal> { 0.10m, 0.20m, 0.30m };
+
+        // Act
+        var result = UsageMetricsCalculator.WeightedAverage(values, 3);
+
+        // Assert
+        Assert.Equal(0.2333m, Math.Round(result, 4));
+    }
+
+    [Fact]
+    public void WeightedAverage_FewerWeeksThanWindow_UsesAvailableWeeks()
+    {
+        // Player only has 2 weeks but we request 5-week average
+        var values = new List<decimal> { 0.20m, 0.30m };
+
+        var result = UsageMetricsCalculator.WeightedAverage(values, 5);
+
+        // Should not throw — uses 2-week weighted average instead
+        Assert.True(result > 0m);
+    }
+
+    [Fact]
+    public void WeightedAverage_EmptyList_ReturnsZero()
+    {
+        var result = UsageMetricsCalculator
+            .WeightedAverage([], 3);
+
+        Assert.Equal(0m, result);
+    }
+
+    [Fact]
+    public void CalculateWopr_UsesCorrectFormula()
+    {
+        // WOPR = (targetShare * 1.5) + (airYardsShare * 0.7)
+        // (0.25 * 1.5) + (0.30 * 0.7) = 0.375 + 0.210 = 0.585
+        var result = UsageMetricsCalculator.CalculateWopr(0.25m, 0.30m);
+
+        Assert.Equal(0.585m, result);
+    }
+
+    [Fact]
+    public void SimpleAverage_ReturnsCorrectMean()
+    {
+        var values = new List<decimal> { 0.10m, 0.20m, 0.30m };
+
+        var result = UsageMetricsCalculator.SimpleAverage(values);
+
+        Assert.Equal(0.20m, result);
+    }
+}


### PR DESCRIPTION
- Add PlayerUsageMetricsDocument with Decimal128 serialization
- Add SnapCountDocument and repository
- Add UsageMetricsService with weighted rolling averages (3wk/5wk/season)
- Add UsageMetricsCalculator with WOPR calculation
- Add UsageMetricsAggregationJob registered in Hangfire
- Add UsageMetricsController GET endpoints
- Fix BSON class maps for all domain documents
- Register global DecimalSerializer for Decimal128 storage
- Round decimal values to 4 places

Closes #213