### PR TITLE
UI-001: Fix bottom nav — remove duplicate button, correct routes, fix…

### DIFF
--- a/FF.WebBlazor/Shared/MainLayout.razor
+++ b/FF.WebBlazor/Shared/MainLayout.razor
@@ -116,20 +116,16 @@
                            OnClick='@(() => Navigate(""))' />
             <MudIconButton Icon="@Icons.Material.Filled.Groups"
                            Color="@NavColor("my-team")"
-                           title="My Team"
+                           title="My Roster"
                            OnClick='@(() => Navigate("my-team"))' />
-            <MudIconButton Icon="@Icons.Material.Filled.SportsMma"
-                           Color="@NavColor("my-matchup")"
-                           title="My Matchup"
-                           OnClick='@(() => Navigate("my-matchup"))' />
             <MudIconButton Icon="@Icons.Material.Filled.TrendingUp"
                            Color="@NavColor("waiver-wire")"
                            title="Waiver Wire"
                            OnClick='@(() => Navigate("waiver-wire"))' />
-            <MudIconButton Icon="@Icons.Material.Filled.MoreHoriz"
-                           Color="Color.Inherit"
-                           title="More"
-                           OnClick="ToggleDrawer" />
+            <MudIconButton Icon="@Icons.Material.Filled.Analytics"
+                           Color="@NavColor("projections")"
+                           title="Players"
+                           OnClick='@(() => Navigate("projections"))' />
             <MudIconButton Icon="@Icons.Material.Filled.MoreHoriz"
                            Color="Color.Inherit"
                            title="More"

--- a/FF.WebBlazor/wwwroot/css/app.css
+++ b/FF.WebBlazor/wwwroot/css/app.css
@@ -757,3 +757,18 @@ td.numeric,
     font-weight: 700 !important;
     font-size: 0.65rem !important;
 }
+
+/* ── Bottom Nav (xs only) ──────────────────────────────── */
+.fc-bottom-nav {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 56px;
+    display: flex;
+    align-items: center;
+    justify-content: space-around;
+    background-color: var(--fc-surface) !important;
+    border-top: 1px solid var(--fc-border) !important;
+    z-index: 1300;
+}


### PR DESCRIPTION
UI-001: Responsive shell cleanup

- Remove duplicate MoreHoriz button from bottom nav
- Correct bottom nav routes and icon labels (My Roster, Waiver Wire, Players, More)
- Add fixed positioning to fc-bottom-nav so it sticks to bottom of screen on mobile
- z-index 1300 ensures nav renders above content