### PR TITLE
NAV-001: Remove League Pulse from home, hide league dropdown on home,…

### DIFF
--- a/FF.WebBlazor/Pages/Index.razor
+++ b/FF.WebBlazor/Pages/Index.razor
@@ -109,48 +109,6 @@ else if (!_loading)
     </MudAlert>
 }
 
-@* ── LEAGUE-WIDE PULSE ────────────────────────────────────── *@
-<MudText Typo="Typo.overline" Class="fc-section-label mb-3 d-block">LEAGUE PULSE</MudText>
-<MudGrid Spacing="3" Class="mb-6">
-    <MudItem xs="6" sm="3">
-        <MudPaper Class="fc-stat-card" Elevation="0">
-            <MudIcon Icon="@Icons.Material.Filled.People" Class="fc-stat-card-icon" />
-            <MudText Typo="Typo.h4" Class="fc-stat-card-value fc-cyan">@_playerCount</MudText>
-            <MudText Typo="Typo.body2" Class="mud-text-secondary">Players Projected</MudText>
-        </MudPaper>
-    </MudItem>
-    <MudItem xs="6" sm="3">
-        <MudPaper Class="fc-stat-card" Elevation="0">
-            <MudIcon Icon="@Icons.Material.Filled.TrendingUp" Class="fc-stat-card-icon" />
-            <MudText Typo="Typo.h4" Class="fc-stat-card-value fc-boom"
-                     Style="font-size:1rem; line-height:1.3;">
-                @_topBoomPlayer
-            </MudText>
-            <MudText Typo="Typo.body2" Class="mud-text-secondary">Top Boom Candidate</MudText>
-        </MudPaper>
-    </MudItem>
-    <MudItem xs="6" sm="3">
-        <MudPaper Class="fc-stat-card" Elevation="0">
-            <MudIcon Icon="@Icons.Material.Filled.AutoAwesome" Class="fc-stat-card-icon" />
-            <MudText Typo="Typo.h4" Class="fc-stat-card-value fc-ceiling"
-                     Style="font-size:1rem; line-height:1.3;">
-                @_topCeilingPlayer
-            </MudText>
-            <MudText Typo="Typo.body2" Class="mud-text-secondary">Highest Ceiling</MudText>
-        </MudPaper>
-    </MudItem>
-    <MudItem xs="6" sm="3">
-        <MudPaper Class="fc-stat-card" Elevation="0">
-            <MudIcon Icon="@Icons.Material.Filled.Warning" Class="fc-stat-card-icon" />
-            <MudText Typo="Typo.h4" Class="fc-stat-card-value"
-                     Style="@(_leagueInjuryCount > 0 ? "color:#F87171;" : "")">
-                @_leagueInjuryCount
-            </MudText>
-            <MudText Typo="Typo.body2" Class="mud-text-secondary">Active Injuries</MudText>
-        </MudPaper>
-    </MudItem>
-</MudGrid>
-
 @* ── QUICK ACCESS ─────────────────────────────────────────── *@
 <MudText Typo="Typo.overline" Class="fc-section-label mb-3 d-block">QUICK ACCESS</MudText>
 <MudGrid Spacing="3">
@@ -332,7 +290,7 @@ else if (!_loading)
     private void NavigateToLeague(string sleeperLeagueId)
     {
         LeagueState.ActiveLeagueId = sleeperLeagueId;
-        Nav.NavigateTo("/my-team");
+        Nav.NavigateTo("/my-league");
     }
 
     // ── View models ──────────────────────────────────────────────────

--- a/FF.WebBlazor/Shared/MainLayout.razor
+++ b/FF.WebBlazor/Shared/MainLayout.razor
@@ -30,7 +30,7 @@
 
         @* Mobile league pill — only visible xs/sm, sits in AppBar *@
         <MudHidden Breakpoint="Breakpoint.MdAndUp">
-            @if (_leagues.Count > 0)
+            @if (_leagues.Count > 0 && _currentPath != "")
             {
                 <MudSelect T="string"
                            Value="_activeLeagueId"
@@ -80,7 +80,7 @@
     <MudMainContent Class="fc-main-content">
         @* Desktop league selector — hidden on mobile (pill is in AppBar instead) *@
         <MudHidden Breakpoint="Breakpoint.SmAndDown">
-            @if (_leagues.Count > 0)
+            @if (_leagues.Count > 0 && _currentPath != "")
             {
                 <div class="fc-league-bar">
                     <MudSelect T="string"


### PR DESCRIPTION
NAV-001: Home page cleanup

- Remove League Pulse section (platform-wide stats not league-scoped)
- Hide league dropdown in AppBar and league bar on home page (/ route)
- League card click now navigates to /my-league instead of /my-team
- Remove unused _playerCount, _topBoomPlayer, _topCeilingPlayer, _leagueInjuryCount fields and related API calls